### PR TITLE
Fix CVE dependency issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-mqtt</artifactId>
-                <version>4.1.66.Final</version>
+                <version>4.1.77.Final</version>
             </dependency>
             <dependency>
                 <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
Fix issue #21   by update dependency io.netty:netty-codec-mqtt to 4.1.77.Fianl @1ssqq1lxr 